### PR TITLE
Bug fix - Undefined property: GitHubHook::$_remote_ip

### DIFF
--- a/class.GitHubHook.php
+++ b/class.GitHubHook.php
@@ -153,7 +153,7 @@ class GitHubHook
    */
   public function deploy() {
 	// Check the remote is a whitelisted GitHub public ip.
-    if ($this->ip_in_cidrs($this->_remote_ip, $this->_github_public_cidrs)) {
+    if ($this->ip_in_cidrs($this->_remoteIp, $this->_github_public_cidrs)) {
       foreach ($this->_branches as $branch) {
         if ($this->_payload->ref == 'refs/heads/' . $branch['name']) {
 


### PR DESCRIPTION
Changed _remote_ip to _remoteIp

Look like in the previous commit a variable name was accidentally changed.
Or something else was going wrong with my setup.

I Started implementing this script on my server tonight and making this change fixes things for me. So assumed it was a bug.
